### PR TITLE
Fix circular import in AppLayout

### DIFF
--- a/src/components/shared/AppLayout.tsx
+++ b/src/components/shared/AppLayout.tsx
@@ -4,7 +4,7 @@ import React, { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import { LogOut, User, ShoppingCart, Package, BarChart3, Settings } from 'lucide-react';
-import { Button } from '@/components/shared';
+import { Button } from './Button';
 import { useAuthStore, useCanAccess } from '@/stores/authStore';
 
 interface AppLayoutProps {


### PR DESCRIPTION
Fix circular import dependency in `AppLayout.tsx` by directly importing `Button`.

The `AppLayout` component was importing `Button` from `@/components/shared`, which resolved to the `index.ts` file. As `index.ts` also exports `AppLayout`, this created a circular dependency. Changing the import to `./Button` resolves this issue.