### PR TITLE
Fix discount calculation bug

### DIFF
--- a/src/stores/posStore.ts
+++ b/src/stores/posStore.ts
@@ -106,9 +106,10 @@ export const usePOSStore = create<POSStore>()(
             discountPercentage: cart.discountPercentage // Keep original percentage
           };
         }
-        // For fixed discounts or no discounts, return current values
+        // For fixed discounts, ensure they don't exceed the new subtotal
+        const cappedFixedDiscount = Math.min(cart.discount, newSubtotal);
         return { 
-          discount: cart.discount, 
+          discount: cappedFixedDiscount, 
           discountPercentage: cart.discountPercentage 
         };
       },


### PR DESCRIPTION
Cap fixed discounts in `recalculateDiscountAmount` to prevent them from exceeding the cart subtotal.

Previously, `recalculateDiscountAmount` only capped percentage discounts. Fixed discounts were returned as-is, which could lead to `cart.discount` being greater than `cart.subtotal` if items were removed or quantities reduced after the discount was applied.