### PR TITLE
Fix cart discount display issues

### DIFF
--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -316,7 +316,9 @@ export default function Sales() {
                       {item.discount && (
                         <div className="flex items-center gap-1">
                           <span className="px-2 py-1 bg-green-600 text-white text-xs rounded-full">
-                            {item.discount.type === 'flat' ? `$${item.discount.amount} off total` : `${item.discount.amount}% off`}
+                            {item.discount.type === 'flat' 
+                              ? `${formatCurrency(toCents(Math.min(item.discount.amount, item.price * item.quantity)))} off total` 
+                              : `${item.discount.amount}% off`}
                           </span>
                           <button
                             className="px-1 py-1 text-xs bg-red-600 hover:bg-red-700 text-white rounded"
@@ -385,7 +387,9 @@ export default function Sales() {
                   <div className="text-green-400 text-sm flex items-center justify-end gap-2">
                     <div className="flex items-center gap-2">
                       <span className="px-2 py-1 bg-green-600 text-white text-xs rounded-full">
-                        {cartDiscount.type === 'flat' ? `$${cartDiscount.amount} off total` : `${cartDiscount.amount}% off`}
+                        {cartDiscount.type === 'flat' 
+                          ? `${formatCurrency(toCents(Math.min(cartDiscount.amount, subtotalAmount)))} off total` 
+                          : `${cartDiscount.amount}% off`}
                       </span>
                       <span>Cart Discount: -{formatCurrency(toCents(cartDiscountAmount))}
                         {cartDiscount.reason && <span className="text-gray-400"> ({cartDiscount.reason})</span>}


### PR DESCRIPTION
Improve discount chip accuracy and formatting by using standard currency formatting and capping amounts to the actual applied value.

Previously, cart and item discount chips displayed configured amounts with inconsistent formatting (e.g., "$5.5" instead of "$5.50") and could show misleading values (e.g., "$20 off" for a $15 subtotal). This PR ensures consistent currency display and shows the actual discount applied, capped by the subtotal or item total, aligning with the final cart calculation.