### PR TITLE
Fix cart discount display inconsistency

### DIFF
--- a/src/app/sales/page.tsx
+++ b/src/app/sales/page.tsx
@@ -115,7 +115,7 @@ export default function Sales() {
   
   const cartDiscountAmount = cartDiscount 
     ? cartDiscount.type === 'flat' 
-      ? cartDiscount.amount 
+      ? Math.min(cartDiscount.amount, subtotalAmount) 
       : subtotalAmount * (cartDiscount.amount / 100)
     : 0
     


### PR DESCRIPTION
Cap cart-level flat discounts at the subtotal amount to ensure consistent display and prevent user confusion.